### PR TITLE
Gentoo PPC64LE images

### DIFF
--- a/gentoo-i686/Dockerfile
+++ b/gentoo-i686/Dockerfile
@@ -1,0 +1,17 @@
+FROM gentoo/stage3-x86
+LABEL MAINTAINER="OSU Open Source Lab <dockerhub@osuosl.org>"
+RUN echo 'GENTOO_MIRRORS="http://gentoo.osuosl.org"' >> /etc/portage/make.conf && \
+    echo 'FEATURES="parallel-fetch"' >> /etc/portage/make.conf && \
+    echo 'CLEAN_DELAY=0' >> /etc/portage/make.conf && \
+    echo 'MAKEOPTS="-j16"' >> /etc/portage/make.conf && \
+    mkdir -p /etc/portage/{package.accept_keywords,package.use} && \
+    echo 'net-misc/dhcp -server' >> /etc/portage/package.use/dhcp && \
+    echo 'app-arch/pigz' >> /etc/portage/package.accept_keywords/pigz && \
+    echo 'sys-kernel/dracut' >> /etc/portage/package.accept_keywords/dracut
+RUN emerge-webrsync && \
+    emerge -q app-portage/eix app-portage/gentoolkit-dev \
+    app-portage/portage-utils dev-vcs/git app-editors/vim sys-apps/ed \
+    sys-devel/bc app-arch/pigz net-misc/dhcp net-fs/nfs-utils \
+    sys-fs/lvm2 sys-fs/mdadm sys-fs/multipath-tools sys-kernel/dracut && \
+    rm -rf /usr/portage
+CMD ["/bin/bash"]

--- a/gentoo-i686/Dockerfile
+++ b/gentoo-i686/Dockerfile
@@ -9,7 +9,7 @@ RUN echo 'GENTOO_MIRRORS="http://gentoo.osuosl.org"' >> /etc/portage/make.conf &
     echo 'app-arch/pigz' >> /etc/portage/package.accept_keywords/pigz && \
     echo 'sys-kernel/dracut' >> /etc/portage/package.accept_keywords/dracut
 RUN emerge-webrsync && \
-    emerge -q app-portage/eix app-portage/gentoolkit-dev \
+    emerge -q app-portage/eix app-portage/gentoolkit-dev app-portage/repoman \
     app-portage/portage-utils dev-vcs/git app-editors/vim sys-apps/ed \
     sys-devel/bc app-arch/pigz net-misc/dhcp net-fs/nfs-utils \
     sys-fs/lvm2 sys-fs/mdadm sys-fs/multipath-tools sys-kernel/dracut && \

--- a/gentoo-ppc64le/Dockerfile
+++ b/gentoo-ppc64le/Dockerfile
@@ -4,11 +4,13 @@ RUN echo 'GENTOO_MIRRORS="http://gentoo.osuosl.org"' >> /etc/portage/make.conf &
     echo 'FEATURES="parallel-fetch"' >> /etc/portage/make.conf && \
     echo 'CLEAN_DELAY=0' >> /etc/portage/make.conf && \
     echo 'MAKEOPTS="-j20"' >> /etc/portage/make.conf && \
-    mkdir -p /etc/portage/package.accept_keywords && \
+    mkdir -p /etc/portage/{package.accept_keywords,package.use} && \
+    echo 'net-misc/dhcp -server' >> /etc/portage/package.use/dhcp && \
     echo 'app-arch/pigz' >> /etc/portage/package.accept_keywords/pigz
 RUN emerge-webrsync && \
     emerge -q app-portage/eix app-portage/gentoolkit-dev \
     app-portage/portage-utils dev-vcs/git app-editors/vim sys-apps/ed \
-    sys-devel/bc app-arch/pigz && \
+    sys-devel/bc app-arch/pigz net-misc/dhcp net-fs/nfs-utils \
+    sys-fs/lvm2 sys-fs/mdadm sys-fs/multipath-tools sys-kernel/dracut && \
     rm -rf /usr/portage/
 CMD ["/bin/bash"]

--- a/gentoo-ppc64le/Dockerfile
+++ b/gentoo-ppc64le/Dockerfile
@@ -6,7 +6,8 @@ RUN echo 'GENTOO_MIRRORS="http://gentoo.osuosl.org"' >> /etc/portage/make.conf &
     echo 'MAKEOPTS="-j20"' >> /etc/portage/make.conf && \
     mkdir -p /etc/portage/{package.accept_keywords,package.use} && \
     echo 'net-misc/dhcp -server' >> /etc/portage/package.use/dhcp && \
-    echo 'app-arch/pigz' >> /etc/portage/package.accept_keywords/pigz
+    echo 'app-arch/pigz' >> /etc/portage/package.accept_keywords/pigz && \
+    echo 'sys-kernel/dracut' >> /etc/portage/package.accept_keywords/dracut
 RUN emerge-webrsync && \
     emerge -q app-portage/eix app-portage/gentoolkit-dev \
     app-portage/portage-utils dev-vcs/git app-editors/vim sys-apps/ed \

--- a/gentoo-ppc64le/Dockerfile
+++ b/gentoo-ppc64le/Dockerfile
@@ -3,6 +3,7 @@ LABEL MAINTAINER="OSU Open Source Lab <dockerhub@osuosl.org>"
 RUN echo 'GENTOO_MIRRORS="http://gentoo.osuosl.org"' >> /etc/portage/make.conf
 RUN echo 'FEATURES="parallel-fetch"' >> /etc/portage/make.conf
 RUN echo 'CLEAN_DELAY=0' >> /etc/portage/make.conf
+RUN echo 'MAKEOPTS="-j20"' >> /etc/portage/make.conf
 RUN emerge-webrsync
 RUN eselect profile set default/linux/powerpc/ppc64/17.0/64bit-userland/little-endian/systemd
 RUN emerge -uDU --keep-going --with-bdeps=y -q @world

--- a/gentoo-ppc64le/Dockerfile
+++ b/gentoo-ppc64le/Dockerfile
@@ -1,12 +1,12 @@
 FROM osuosl/gentoo:stage3-ppc64le
 LABEL MAINTAINER="OSU Open Source Lab <dockerhub@osuosl.org>"
-RUN echo 'GENTOO_MIRRORS="http://gentoo.osuosl.org"' >> /etc/portage/make.conf
-RUN echo 'FEATURES="parallel-fetch"' >> /etc/portage/make.conf
-RUN echo 'CLEAN_DELAY=0' >> /etc/portage/make.conf
-RUN echo 'MAKEOPTS="-j20"' >> /etc/portage/make.conf
-RUN emerge-webrsync
-RUN emerge -q app-portage/eix app-portage/gentoolkit-dev \
+RUN echo 'GENTOO_MIRRORS="http://gentoo.osuosl.org"' >> /etc/portage/make.conf && /
+    echo 'FEATURES="parallel-fetch"' >> /etc/portage/make.conf && /
+    echo 'CLEAN_DELAY=0' >> /etc/portage/make.conf && /
+    echo 'MAKEOPTS="-j20"' >> /etc/portage/make.conf
+RUN emerge-webrsync && /
+    emerge -q app-portage/eix app-portage/gentoolkit-dev \
     app-portage/portage-utils dev-vcs/git app-editors/vim sys-apps/ed \
-    sys-devel/bc
-RUN rm -rf /usr/portage/distfiles/*
+    sys-devel/bc && /
+    rm -rf /usr/portage/
 CMD ["/bin/bash"]

--- a/gentoo-ppc64le/Dockerfile
+++ b/gentoo-ppc64le/Dockerfile
@@ -4,6 +4,8 @@ RUN echo 'GENTOO_MIRRORS="http://gentoo.osuosl.org"' >> /etc/portage/make.conf
 RUN echo 'FEATURES="parallel-fetch"' >> /etc/portage/make.conf
 RUN echo 'CLEAN_DELAY=0' >> /etc/portage/make.conf
 RUN emerge-webrsync
+RUN eselect profile set default/linux/powerpc/ppc64/17.0/64bit-userland/little-endian/systemd
+RUN emerge -uDU --keep-going --with-bdeps=y -q @world
 RUN emerge -q emerge layman
 RUN layman -L && layman -a ppc64le && \
     cat "source /var/lib/layman/make.conf" >> /etc/portage/make.conf

--- a/gentoo-ppc64le/Dockerfile
+++ b/gentoo-ppc64le/Dockerfile
@@ -3,10 +3,12 @@ LABEL MAINTAINER="OSU Open Source Lab <dockerhub@osuosl.org>"
 RUN echo 'GENTOO_MIRRORS="http://gentoo.osuosl.org"' >> /etc/portage/make.conf && \
     echo 'FEATURES="parallel-fetch"' >> /etc/portage/make.conf && \
     echo 'CLEAN_DELAY=0' >> /etc/portage/make.conf && \
-    echo 'MAKEOPTS="-j20"' >> /etc/portage/make.conf
+    echo 'MAKEOPTS="-j20"' >> /etc/portage/make.conf && \
+    mkdir -p /etc/portage/package.accept_keywords && \
+    echo 'app-arch/pigz' >> /etc/portage/package.accept_keywords/pigz
 RUN emerge-webrsync && \
     emerge -q app-portage/eix app-portage/gentoolkit-dev \
     app-portage/portage-utils dev-vcs/git app-editors/vim sys-apps/ed \
-    sys-devel/bc && \
+    sys-devel/bc app-arch/pigz && \
     rm -rf /usr/portage/
 CMD ["/bin/bash"]

--- a/gentoo-ppc64le/Dockerfile
+++ b/gentoo-ppc64le/Dockerfile
@@ -1,0 +1,14 @@
+FROM powerkvm/gentoo
+LABEL MAINTAINER="OSU Open Source Lab <dockerhub@osuosl.org>"
+RUN echo 'GENTOO_MIRRORS="http://gentoo.osuosl.org"' >> /etc/portage/make.conf
+RUN echo 'FEATURES="parallel-fetch"' >> /etc/portage/make.conf
+RUN echo 'CLEAN_DELAY=0' >> /etc/portage/make.conf
+RUN emerge-webrsync
+RUN emerge -q emerge layman
+RUN layman -L && layman -a ppc64le && \
+    cat "source /var/lib/layman/make.conf" >> /etc/portage/make.conf
+RUN emerge -q app-portage/eix app-portage/gentoolkit-dev \
+    app-portage/portage-utils dev-vcs/git app-editors/vim sys-apps/ed \
+    sys-devel/bc
+RUN rm -rf /usr/portage/distfiles/*
+CMD ["/bin/bash"]

--- a/gentoo-ppc64le/Dockerfile
+++ b/gentoo-ppc64le/Dockerfile
@@ -1,12 +1,12 @@
 FROM osuosl/gentoo:stage3-ppc64le
 LABEL MAINTAINER="OSU Open Source Lab <dockerhub@osuosl.org>"
-RUN echo 'GENTOO_MIRRORS="http://gentoo.osuosl.org"' >> /etc/portage/make.conf && /
-    echo 'FEATURES="parallel-fetch"' >> /etc/portage/make.conf && /
-    echo 'CLEAN_DELAY=0' >> /etc/portage/make.conf && /
+RUN echo 'GENTOO_MIRRORS="http://gentoo.osuosl.org"' >> /etc/portage/make.conf && \
+    echo 'FEATURES="parallel-fetch"' >> /etc/portage/make.conf && \
+    echo 'CLEAN_DELAY=0' >> /etc/portage/make.conf && \
     echo 'MAKEOPTS="-j20"' >> /etc/portage/make.conf
-RUN emerge-webrsync && /
+RUN emerge-webrsync && \
     emerge -q app-portage/eix app-portage/gentoolkit-dev \
     app-portage/portage-utils dev-vcs/git app-editors/vim sys-apps/ed \
-    sys-devel/bc && /
+    sys-devel/bc && \
     rm -rf /usr/portage/
 CMD ["/bin/bash"]

--- a/gentoo-ppc64le/Dockerfile
+++ b/gentoo-ppc64le/Dockerfile
@@ -9,7 +9,7 @@ RUN echo 'GENTOO_MIRRORS="http://gentoo.osuosl.org"' >> /etc/portage/make.conf &
     echo 'app-arch/pigz' >> /etc/portage/package.accept_keywords/pigz && \
     echo 'sys-kernel/dracut' >> /etc/portage/package.accept_keywords/dracut
 RUN emerge-webrsync && \
-    emerge -q app-portage/eix app-portage/gentoolkit-dev \
+    emerge -q app-portage/eix app-portage/gentoolkit-dev app-portage/repoman \
     app-portage/portage-utils dev-vcs/git app-editors/vim sys-apps/ed \
     sys-devel/bc app-arch/pigz net-misc/dhcp net-fs/nfs-utils \
     sys-fs/lvm2 sys-fs/mdadm sys-fs/multipath-tools sys-kernel/dracut && \

--- a/gentoo-ppc64le/Dockerfile
+++ b/gentoo-ppc64le/Dockerfile
@@ -1,15 +1,10 @@
-FROM powerkvm/gentoo
+FROM osuosl/gentoo:stage3-ppc64le
 LABEL MAINTAINER="OSU Open Source Lab <dockerhub@osuosl.org>"
 RUN echo 'GENTOO_MIRRORS="http://gentoo.osuosl.org"' >> /etc/portage/make.conf
 RUN echo 'FEATURES="parallel-fetch"' >> /etc/portage/make.conf
 RUN echo 'CLEAN_DELAY=0' >> /etc/portage/make.conf
 RUN echo 'MAKEOPTS="-j20"' >> /etc/portage/make.conf
 RUN emerge-webrsync
-RUN eselect profile set default/linux/powerpc/ppc64/17.0/64bit-userland/little-endian/systemd
-RUN emerge -uDU --keep-going --with-bdeps=y -q @world
-RUN emerge -q emerge layman
-RUN layman -L && layman -a ppc64le && \
-    cat "source /var/lib/layman/make.conf" >> /etc/portage/make.conf
 RUN emerge -q app-portage/eix app-portage/gentoolkit-dev \
     app-portage/portage-utils dev-vcs/git app-editors/vim sys-apps/ed \
     sys-devel/bc

--- a/gentoo/Dockerfile
+++ b/gentoo/Dockerfile
@@ -3,10 +3,12 @@ LABEL MAINTAINER="OSU Open Source Lab <dockerhub@osuosl.org>"
 RUN echo 'GENTOO_MIRRORS="http://gentoo.osuosl.org"' >> /etc/portage/make.conf && \
     echo 'FEATURES="parallel-fetch"' >> /etc/portage/make.conf && \
     echo 'CLEAN_DELAY=0' >> /etc/portage/make.conf && \
-    echo 'MAKEOPTS="-j16"' >> /etc/portage/make.conf
+    echo 'MAKEOPTS="-j16"' >> /etc/portage/make.conf && \
+    mkdir -p /etc/portage/package.accept_keywords && \
+    echo 'app-arch/pigz' >> /etc/portage/package.accept_keywords/pigz
 RUN emerge-webrsync && \
     emerge -q app-portage/eix app-portage/gentoolkit-dev \
     app-portage/portage-utils dev-vcs/git app-editors/vim sys-apps/ed \
-    sys-devel/bc && \
+    sys-devel/bc app-arch/pigz && \
     rm -rf /usr/portage
 CMD ["/bin/bash"]

--- a/gentoo/Dockerfile
+++ b/gentoo/Dockerfile
@@ -3,6 +3,7 @@ LABEL MAINTAINER="OSU Open Source Lab <dockerhub@osuosl.org>"
 RUN echo 'GENTOO_MIRRORS="http://gentoo.osuosl.org"' >> /etc/portage/make.conf
 RUN echo 'FEATURES="parallel-fetch"' >> /etc/portage/make.conf
 RUN echo 'CLEAN_DELAY=0' >> /etc/portage/make.conf
+RUN echo 'MAKEOPTS="-j16"' >> /etc/portage/make.conf
 RUN emerge-webrsync
 RUN emerge -q app-portage/eix app-portage/gentoolkit-dev \
     app-portage/portage-utils dev-vcs/git app-editors/vim sys-apps/ed \

--- a/gentoo/Dockerfile
+++ b/gentoo/Dockerfile
@@ -5,6 +5,7 @@ RUN echo 'FEATURES="parallel-fetch"' >> /etc/portage/make.conf
 RUN echo 'CLEAN_DELAY=0' >> /etc/portage/make.conf
 RUN emerge-webrsync
 RUN emerge -q app-portage/eix app-portage/gentoolkit-dev \
-    app-portage/portage-utils dev-vcs/git app-editors/vim
+    app-portage/portage-utils dev-vcs/git app-editors/vim sys-apps/ed \
+    sys-devel/bc
 RUN rm -rf /usr/portage/distfiles/*
 CMD ["/bin/bash"]

--- a/gentoo/Dockerfile
+++ b/gentoo/Dockerfile
@@ -4,11 +4,13 @@ RUN echo 'GENTOO_MIRRORS="http://gentoo.osuosl.org"' >> /etc/portage/make.conf &
     echo 'FEATURES="parallel-fetch"' >> /etc/portage/make.conf && \
     echo 'CLEAN_DELAY=0' >> /etc/portage/make.conf && \
     echo 'MAKEOPTS="-j16"' >> /etc/portage/make.conf && \
-    mkdir -p /etc/portage/package.accept_keywords && \
+    mkdir -p /etc/portage/{package.accept_keywords,package.use} && \
+    echo 'net-misc/dhcp -server' >> /etc/portage/package.use/dhcp && \
     echo 'app-arch/pigz' >> /etc/portage/package.accept_keywords/pigz
 RUN emerge-webrsync && \
     emerge -q app-portage/eix app-portage/gentoolkit-dev \
     app-portage/portage-utils dev-vcs/git app-editors/vim sys-apps/ed \
-    sys-devel/bc app-arch/pigz && \
+    sys-devel/bc app-arch/pigz net-misc/dhcp net-fs/nfs-utils \
+    sys-fs/lvm2 sys-fs/mdadm sys-fs/multipath-tools sys-kernel/dracut && \
     rm -rf /usr/portage
 CMD ["/bin/bash"]

--- a/gentoo/Dockerfile
+++ b/gentoo/Dockerfile
@@ -6,7 +6,8 @@ RUN echo 'GENTOO_MIRRORS="http://gentoo.osuosl.org"' >> /etc/portage/make.conf &
     echo 'MAKEOPTS="-j16"' >> /etc/portage/make.conf && \
     mkdir -p /etc/portage/{package.accept_keywords,package.use} && \
     echo 'net-misc/dhcp -server' >> /etc/portage/package.use/dhcp && \
-    echo 'app-arch/pigz' >> /etc/portage/package.accept_keywords/pigz
+    echo 'app-arch/pigz' >> /etc/portage/package.accept_keywords/pigz && \
+    echo 'sys-kernel/dracut' >> /etc/portage/package.accept_keywords/dracut
 RUN emerge-webrsync && \
     emerge -q app-portage/eix app-portage/gentoolkit-dev \
     app-portage/portage-utils dev-vcs/git app-editors/vim sys-apps/ed \

--- a/gentoo/Dockerfile
+++ b/gentoo/Dockerfile
@@ -9,7 +9,7 @@ RUN echo 'GENTOO_MIRRORS="http://gentoo.osuosl.org"' >> /etc/portage/make.conf &
     echo 'app-arch/pigz' >> /etc/portage/package.accept_keywords/pigz && \
     echo 'sys-kernel/dracut' >> /etc/portage/package.accept_keywords/dracut
 RUN emerge-webrsync && \
-    emerge -q app-portage/eix app-portage/gentoolkit-dev \
+    emerge -q app-portage/eix app-portage/gentoolkit-dev app-portage/repoman \
     app-portage/portage-utils dev-vcs/git app-editors/vim sys-apps/ed \
     sys-devel/bc app-arch/pigz net-misc/dhcp net-fs/nfs-utils \
     sys-fs/lvm2 sys-fs/mdadm sys-fs/multipath-tools sys-kernel/dracut && \

--- a/gentoo/Dockerfile
+++ b/gentoo/Dockerfile
@@ -1,12 +1,12 @@
 FROM gentoo/stage3-amd64
 LABEL MAINTAINER="OSU Open Source Lab <dockerhub@osuosl.org>"
-RUN echo 'GENTOO_MIRRORS="http://gentoo.osuosl.org"' >> /etc/portage/make.conf
-RUN echo 'FEATURES="parallel-fetch"' >> /etc/portage/make.conf
-RUN echo 'CLEAN_DELAY=0' >> /etc/portage/make.conf
-RUN echo 'MAKEOPTS="-j16"' >> /etc/portage/make.conf
-RUN emerge-webrsync
-RUN emerge -q app-portage/eix app-portage/gentoolkit-dev \
+RUN echo 'GENTOO_MIRRORS="http://gentoo.osuosl.org"' >> /etc/portage/make.conf && \
+    echo 'FEATURES="parallel-fetch"' >> /etc/portage/make.conf && \
+    echo 'CLEAN_DELAY=0' >> /etc/portage/make.conf && \
+    echo 'MAKEOPTS="-j16"' >> /etc/portage/make.conf
+RUN emerge-webrsync && \
+    emerge -q app-portage/eix app-portage/gentoolkit-dev \
     app-portage/portage-utils dev-vcs/git app-editors/vim sys-apps/ed \
-    sys-devel/bc
-RUN rm -rf /usr/portage/distfiles/*
+    sys-devel/bc && \
+    rm -rf /usr/portage
 CMD ["/bin/bash"]

--- a/gentoo/ppc64le/Dockerfile
+++ b/gentoo/ppc64le/Dockerfile
@@ -1,0 +1,39 @@
+# This Dockerfile creates a gentoo stage3 container image. By default it
+# creates a stage3-ppc64le image. It utilizes a multi-stage build and requires
+# docker-17.05.0 or later. It fetches a daily snapshot from the official
+# sources and verifies its checksum as well as its gpg signature.
+
+# As gpg keyservers sometimes are unreliable, we use multiple gpg server pools
+# to fetch the signing key.
+
+ARG BOOTSTRAP
+FROM ${BOOTSTRAP:-ppc64le/alpine:3.7} as builder
+
+WORKDIR /gentoo
+
+ARG ARCH=ppc64le
+ARG MICROARCH=ppc64le
+ARG SUFFIX="-20180117"
+ARG DIST="https://ftp.osuosl.org/pub/osl/openpower/gentoo/releases"
+ARG SIGNING_KEY="0x2DF30655A70B13B7"
+ARG STAGE3="stage3-${MICROARCH}${SUFFIX}.tar.bz2"
+
+RUN echo "Building Gentoo Container image for ${ARCH} ${SUFFIX} fetching from ${DIST}" \
+ && apk --no-cache add gnupg tar wget xz \
+ && wget -q "${DIST}/${STAGE3}" "${DIST}/${STAGE3}.CONTENTS" "${DIST}/${STAGE3}.DIGESTS.asc" \
+ && gpg --list-keys \
+ && echo "standard-resolver" >> ~/.gnupg/dirmngr.conf \
+ && echo "honor-http-proxy" >> ~/.gnupg/dirmngr.conf \
+ && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
+ && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys ${SIGNING_KEY} \
+ && gpg --verify "${STAGE3}.DIGESTS.asc" \
+ && awk '/# SHA512 HASH/{getline; print}' ${STAGE3}.DIGESTS.asc | sha512sum -c \
+ && tar xpf "${STAGE3}" --xattrs --numeric-owner \
+ && echo 'UTC' > etc/timezone \
+ && rm ${STAGE3}.DIGESTS.asc ${STAGE3}.CONTENTS ${STAGE3}
+
+FROM scratch
+
+WORKDIR /
+COPY --from=builder /gentoo/ /
+CMD ["/bin/bash"]


### PR DESCRIPTION
This updates/creates three images:

### gentoo:latest (updated)
- Set ``MAKEOPTS`` to something sane
- Add ``sys-apps/ed`` and ``sys-devel/bc`` which are needed for kernel building
- Remove ``/usr/portage`` to save space
- Reduce to two ``RUN`` steps to ease building

### gentoo:stage3-ppc64le (new)
In addition to the above..
- Build a ppc64le stage3 image using [gentoo-docker-images](https://github.com/gentoo/gentoo-docker-images) as a template
- Stages were built originally using the [powerkvm/gentoo](https://hub.docker.com/r/powerkvm/gentoo/) image since no upstream stage3 exist
- The stage is currently hosted on our FTP cluster

### gentoo-ppc64le (new)
In addition to the updates mentioned in gentoo:latest..
- This uses the gentoo:stage3-ppc64le image above to create a stage4 image that we can use for building kernel images.