### PR TITLE
Use gcc 7.3 which has retpoline support

### DIFF
--- a/gentoo-i686/Dockerfile
+++ b/gentoo-i686/Dockerfile
@@ -7,11 +7,14 @@ RUN echo 'GENTOO_MIRRORS="http://gentoo.osuosl.org"' >> /etc/portage/make.conf &
     mkdir -p /etc/portage/{package.accept_keywords,package.use} && \
     echo 'net-misc/dhcp -server' >> /etc/portage/package.use/dhcp && \
     echo 'app-arch/pigz' >> /etc/portage/package.accept_keywords/pigz && \
-    echo 'sys-kernel/dracut' >> /etc/portage/package.accept_keywords/dracut
+    echo 'sys-kernel/dracut' >> /etc/portage/package.accept_keywords/dracut && \
+    echo 'sys-devel/gcc' >> /etc/portage/package.accept_keywords/gcc
 RUN emerge-webrsync && \
     emerge -q app-portage/eix app-portage/gentoolkit-dev app-portage/repoman \
     app-portage/portage-utils dev-vcs/git app-editors/vim sys-apps/ed \
     sys-devel/bc app-arch/pigz net-misc/dhcp net-fs/nfs-utils \
-    sys-fs/lvm2 sys-fs/mdadm sys-fs/multipath-tools sys-kernel/dracut && \
+    sys-fs/lvm2 sys-fs/mdadm sys-fs/multipath-tools sys-kernel/dracut \
+    =sys-devel/gcc-7.3* && \
+    gcc-config i686-pc-linux-gnu-7.3.0 && \
     rm -rf /usr/portage
 CMD ["/bin/bash"]

--- a/gentoo-ppc64le/Dockerfile
+++ b/gentoo-ppc64le/Dockerfile
@@ -7,11 +7,14 @@ RUN echo 'GENTOO_MIRRORS="http://gentoo.osuosl.org"' >> /etc/portage/make.conf &
     mkdir -p /etc/portage/{package.accept_keywords,package.use} && \
     echo 'net-misc/dhcp -server' >> /etc/portage/package.use/dhcp && \
     echo 'app-arch/pigz' >> /etc/portage/package.accept_keywords/pigz && \
-    echo 'sys-kernel/dracut' >> /etc/portage/package.accept_keywords/dracut
+    echo 'sys-kernel/dracut' >> /etc/portage/package.accept_keywords/dracut && \
+    echo 'sys-devel/gcc' >> /etc/portage/package.accept_keywords/gcc
 RUN emerge-webrsync && \
     emerge -q app-portage/eix app-portage/gentoolkit-dev app-portage/repoman \
     app-portage/portage-utils dev-vcs/git app-editors/vim sys-apps/ed \
     sys-devel/bc app-arch/pigz net-misc/dhcp net-fs/nfs-utils \
-    sys-fs/lvm2 sys-fs/mdadm sys-fs/multipath-tools sys-kernel/dracut && \
+    sys-fs/lvm2 sys-fs/mdadm sys-fs/multipath-tools sys-kernel/dracut \
+    =sys-devel/gcc-7.3* && \
+    gcc-config powerpc64le-unknown-linux-gnu-7.3.0 && \
     rm -rf /usr/portage/
 CMD ["/bin/bash"]

--- a/gentoo/Dockerfile
+++ b/gentoo/Dockerfile
@@ -7,11 +7,14 @@ RUN echo 'GENTOO_MIRRORS="http://gentoo.osuosl.org"' >> /etc/portage/make.conf &
     mkdir -p /etc/portage/{package.accept_keywords,package.use} && \
     echo 'net-misc/dhcp -server' >> /etc/portage/package.use/dhcp && \
     echo 'app-arch/pigz' >> /etc/portage/package.accept_keywords/pigz && \
-    echo 'sys-kernel/dracut' >> /etc/portage/package.accept_keywords/dracut
+    echo 'sys-kernel/dracut' >> /etc/portage/package.accept_keywords/dracut && \
+    echo 'sys-devel/gcc' >> /etc/portage/package.accept_keywords/gcc
 RUN emerge-webrsync && \
     emerge -q app-portage/eix app-portage/gentoolkit-dev app-portage/repoman \
     app-portage/portage-utils dev-vcs/git app-editors/vim sys-apps/ed \
     sys-devel/bc app-arch/pigz net-misc/dhcp net-fs/nfs-utils \
-    sys-fs/lvm2 sys-fs/mdadm sys-fs/multipath-tools sys-kernel/dracut && \
+    sys-fs/lvm2 sys-fs/mdadm sys-fs/multipath-tools sys-kernel/dracut \
+    =sys-devel/gcc-7.3* && \
+    gcc-config x86_64-pc-linux-gnu-7.3.0 && \
     rm -rf /usr/portage
 CMD ["/bin/bash"]


### PR DESCRIPTION
Using this version of gcc will provide us an ability to build Linux kernels that
have full spectre_v2 mitigation.