### PR TITLE
Lock various plugins that support netbox 4.4

### DIFF
--- a/.github/workflows/netbox.yml
+++ b/.github/workflows/netbox.yml
@@ -5,9 +5,9 @@ on:
   push:
     branches:
       - master
-    paths: netbox/**
+    paths: netbox/*
   pull_request:
-    paths: netbox/**
+    paths: netbox/*
   schedule:
     # Run weekly on Sundays at 6:00 AM UTC
     - cron: '0 6 * * 0'

--- a/netbox/plugin_requirements.txt
+++ b/netbox/plugin_requirements.txt
@@ -1,30 +1,26 @@
 # NetBox plugins for OSL
 # See: https://github.com/netbox-community/netbox/wiki/Plugins
 
-# LDAP authentication support
-# https://django-auth-ldap.readthedocs.io/
-django-auth-ldap
-
 # Secret/password management for NetBox
 # https://github.com/Onemind-Services-LLC/netbox-secrets
-netbox-secrets
+netbox-secrets~=2.4.2
 
 # Datacenter floor plan visualization
 # https://github.com/netbox-community/netbox-floorplan-plugin
-netbox-floorplan-plugin
+netbox-floorplan-plugin~=0.8.0
 
 # Access Control List management
 # https://github.com/netbox-community/netbox-acls
-netbox-acls
+netbox-acls~=1.9.1
 
 # Network topology visualization
 # https://github.com/netbox-community/netbox-topology-views
-netbox-topology-views
+netbox-topology-views~=4.5.0
 
 # Drag-and-drop rack reordering
 # https://github.com/netbox-community/netbox-reorder-rack
-netbox-reorder-rack
+netbox-reorder-rack~=1.1.4
 
 # Hardware inventory tracking
 # https://github.com/ArnesSI/netbox-inventory
-netbox-inventory
+netbox-inventory~=2.4.1


### PR DESCRIPTION
Netbox 4.5 was released and we started pulling plugins that no longer support
4.4. Not all the plugins we currently use have a release which supports 4.5.

Signed-off-by: Lance Albertson <lance@osuosl.org>
